### PR TITLE
harys.is-truly-a.pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Register
 1. Fork the repo.
 2. [Read the documentation](https://docs.is-truly-a.pro).
-3. Create your json file in the domains directory and create a pull request 
+3. Create your json file in the domains directory and create a pull request. 
 4. After the pull request is merged, DNS should propagate within about 15 minutes to a maximum of 24 hours.
 5. That's all, enjoy your `is-truly-a.pro` domain!
 
@@ -17,7 +17,7 @@
 > Services like Vercel and Netlify which require verifying root domain are not supported as we are not in the Public Suffix List.
 
 ## Issues
-If you have any problems or want to report a subdomain, feel free to [open a issue](https://github.com/is-truly-a-pro/register/issues/new/choose) or join our [Discord server](https://discord.gg/MGSvZBdc4p].
+If you have any problems or want to report a subdomain, feel free to [open a issue](https://github.com/is-truly-a-pro/register/issues/new/choose) or join our [Discord server](https://discord.gg/MGSvZBdc4p).
 
 ### Similar Services
 If you want to find services similar to is-truly-a.pro, please check out [Open Domains](https://github.com/open-domains/register) and [is-a.dev](https://github.com/is-a-dev/register).

--- a/domains/_discord.harys.json
+++ b/domains/_discord.harys.json
@@ -1,7 +1,7 @@
 {
   "owner": {
     "username": "harys722",
-    "email": "contact@harys.is-a.dev"
+    "email": "contact@harys.is-a.dev",
     "discord": "1203357768610746385"
   },
   "record": {

--- a/domains/_discord.harys.json
+++ b/domains/_discord.harys.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "harys722",
+    "email": "contact@harys.is-a.dev"
+    "discord": "1203357768610746385"
+  },
+  "record": {
+    "TXT": ["dh=08389103a2f47a3fcc7212c8a2fbee1bc64ccb39"]
+  }
+}

--- a/domains/harys.json
+++ b/domains/harys.json
@@ -1,0 +1,11 @@
+{
+  "description": "A redirect to my harys.is-a.dev website.",
+  "owner": {
+    "username": "harys722",
+    "email": "contact@harys.is-a.dev",
+    "discord": "1203357768610746385"
+  },
+  "record": {
+    "A": ["89.106.200.1"]
+  }
+}


### PR DESCRIPTION
Registering `harys.is-truly-a.pro` subdomain, and fixed the typo in the README.